### PR TITLE
feat: resolve shorten url

### DIFF
--- a/api/helpers/helpers.go
+++ b/api/helpers/helpers.go
@@ -1,10 +1,15 @@
 package helpers
 
 import (
+	"encoding/json"
 	"net/http"
 	"os"
 	"strings"
 )
+
+type ErrorResponse struct {
+	Error string `json:"error"`
+}
 
 var methodChoices = map[string]string{
 	"get":   "GET",
@@ -49,4 +54,11 @@ func SetHeaders(type_ string, w http.ResponseWriter, status int) {
 		w.Header().Set("Access-Control-Allow-Methods", method)
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
 	}
+}
+
+func SendJSONError(w http.ResponseWriter, statusCode int, errorMessage string) {
+	errorResponse := ErrorResponse{Error: errorMessage}
+	w.Header().Set("content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	json.NewEncoder(w).Encode(errorResponse)
 }

--- a/api/routes/url.go
+++ b/api/routes/url.go
@@ -7,6 +7,8 @@ import (
 )
 
 func URLRoutes(r *mux.Router) {
+	r.HandleFunc("/{short}", controllers.ResolveURL).Methods("GET")
+
 	protectedR := r.NewRoute().Subrouter()
 	protectedR.Use(middleware.Authentication)
 	protectedR.HandleFunc("", controllers.ShortenURL).Methods("POST")

--- a/api/routes/user.go
+++ b/api/routes/user.go
@@ -8,7 +8,7 @@ import (
 
 func UserRoutes(r *mux.Router) {
 	r.HandleFunc("/sign_in_with_google", controllers.SignInWithGoogle).Methods("GET")
-	r.HandleFunc("/google/callback", controllers.CallbackSignInWithGoogle).Methods("POST")
+	r.HandleFunc("/google/callback", controllers.CallbackSignInWithGoogle).Methods("GET")
 
 	protectedR := r.NewRoute().Subrouter()
 	protectedR.Use(middleware.Authentication)


### PR DESCRIPTION
closes #6 

# Brief
- Create an API endpoint to resolve the shortened URL and redirect to the destination URL.
- Handle the case of the URL being expired or not present by redirecting to the `{FRONTEND_URL}/not-found`.