### PR TITLE
feat/ Update and Get All URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 __debug_bin.exe
+node_modules

--- a/api/routes/url.go
+++ b/api/routes/url.go
@@ -7,9 +7,11 @@ import (
 )
 
 func URLRoutes(r *mux.Router) {
-	r.HandleFunc("/{short}", controllers.ResolveURL).Methods("GET")
-
 	protectedR := r.NewRoute().Subrouter()
 	protectedR.Use(middleware.Authentication)
 	protectedR.HandleFunc("", controllers.ShortenURL).Methods("POST")
+	protectedR.HandleFunc("/all", controllers.GetUserURL).Methods("GET")
+	protectedR.HandleFunc("/{id}", controllers.UpdateUrl).Methods("PATCH")
+
+	r.HandleFunc("/{short}", controllers.ResolveURL).Methods("GET")
 }


### PR DESCRIPTION
closes #8 

# Brief
- To create an API endpoint to update and get all user URLs.
- Fix Error handling for Auth middleware.
- The request and response struct for the ShortUrl API is updated. Now the URL (to be shortened) is referenced as `destination` the same as its title in the model schema `destination`, instead of `URL`.
- The GetUrl model utility is updated, it can now accept both urlId or URL short unique code to find the url.

# API Documentation: 

## GET All User URLs:  /url/all (GET)

### Request

- **Endpoint:** `/url/all`
- **Method:** `GET`
- **Content-Type:** `application/json`
- **Authentication:** `Bearer <JWT_TOKEN>`

### Response
- **Status:** `200`
```json
[
  {
    "user": "6595eb7afd12bd445cb59951",
    "destination": "https://x.com",
    "expiry": "2024-01-05T04:49:10.593Z",
    "short": "third",
    "_id": "65985ecdd720dad191d1607c",
    "lastVisited": "2024-01-05T19:55:57.244Z"
  }
]
```

## Update User URL:  /url/`<URL_ID>` (PATCH)

### Request

- **Endpoint:** `/url/<URL_ID>`
- **Method:** `PATCH`
- **Content-Type:** `application/json`
- **Authentication:** `Bearer <JWT_TOKEN>`

**Request Body:**
```json
{
  "destination": "https://example.com/new-url",
  "short": "new-short-url",
  "expiry": {new Date().toISOString()}
}
```

### Response
- **Status:** `204`