### PR TITLE
refact: url resolve flow refact

### DIFF
--- a/api/helpers/helpers.go
+++ b/api/helpers/helpers.go
@@ -62,3 +62,12 @@ func SendJSONError(w http.ResponseWriter, statusCode int, errorMessage string) {
 	w.WriteHeader(statusCode)
 	json.NewEncoder(w).Encode(errorResponse)
 }
+
+func ContainsString(arr *[]string, target *string) bool {
+	for _, s := range *arr {
+		if s == *target {
+			return true
+		}
+	}
+	return false
+}

--- a/api/main.go
+++ b/api/main.go
@@ -16,6 +16,7 @@ import (
 func setupRoutes(router *mux.Router) {
 	routes.UserRoutes(router.PathPrefix("/user").Subrouter())
 	routes.URLRoutes(router.PathPrefix("/url").Subrouter())
+	routes.URLResolveRoutes(router)
 }
 
 func main() {

--- a/api/models/url.go
+++ b/api/models/url.go
@@ -3,6 +3,7 @@ package models
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"example.com/go/url-shortner/helpers"
@@ -48,6 +49,8 @@ func CreateURL(user *User, short string, destination string, expiry int32) (*URL
 	url := URL{User: user, Short: short, Destination: destination, Expiry: urlDoc.Expiry, LastVisited: urlDoc.LastVisited}
 	url.ID = res.InsertedID.(primitive.ObjectID)
 	fmt.Printf("URL created with id %v\n", url.ID)
+
+	url.Short = os.Getenv("DOMAIN") + "/" + url.Short
 
 	return &url, nil
 }
@@ -96,6 +99,7 @@ func GetUserURL(userId primitive.ObjectID) ([]*URLDoc, error) {
 		if e != nil {
 			fmt.Println(err)
 		}
+		result.Short = os.Getenv("DOMAIN") + "/" + result.Short
 		results = append(results, &result)
 	}
 

--- a/api/routes/url.go
+++ b/api/routes/url.go
@@ -13,5 +13,8 @@ func URLRoutes(r *mux.Router) {
 	protectedR.HandleFunc("/all", controllers.GetUserURL).Methods("GET")
 	protectedR.HandleFunc("/{id}", controllers.UpdateUrl).Methods("PATCH")
 
+}
+
+func URLResolveRoutes(r *mux.Router) {
 	r.HandleFunc("/{short}", controllers.ResolveURL).Methods("GET")
 }

--- a/api/utils/jwt.go
+++ b/api/utils/jwt.go
@@ -10,10 +10,9 @@ import (
 	"github.com/golang-jwt/jwt"
 )
 
-var secretKey = []byte(os.Getenv("JWT_SECRET_KEY"))
-var expiry = os.Getenv("JWT_EXPIRY")
-
 func CreateJWT(user *models.User) (*string, error) {
+	var secretKey = []byte(os.Getenv("JWT_SECRET_KEY"))
+	var expiry = os.Getenv("JWT_EXPIRY")
 	expiryTotal, err := strconv.Atoi(expiry)
 	if err != nil {
 		fmt.Println("Error:", err)
@@ -41,6 +40,7 @@ func CreateJWT(user *models.User) (*string, error) {
 }
 
 func VerifyJwt(tokenString string) (*map[string]string, error) {
+	var secretKey = []byte(os.Getenv("JWT_SECRET_KEY"))
 	if tokenString == "" {
 		return nil, fmt.Errorf("invalid token value: %s", tokenString)
 	}


### PR DESCRIPTION
# Brief
- Refactor URL resolve flow
- In response to `ShortenURL` and `GetUserURL`, the `short` key will be the actual shortened URL instead of just the `short`, that is `<DEPLOYED_URL>/<SHORT>`
- Add a check for the `short` to not match any internal URLs.