### PR TITLE
refact: added updated_at and total clicks in url schema

### DIFF
--- a/api/controllers/url.go
+++ b/api/controllers/url.go
@@ -148,7 +148,7 @@ func ResolveURL(w http.ResponseWriter, r *http.Request) {
 
 	if urlExpiredOrNotFound || url == nil {
 		notFoundUrl := os.Getenv("FRONTEND_URL") + "/not-found/redirect"
-		http.Redirect(w, r, notFoundUrl, http.StatusMovedPermanently)
+		http.Redirect(w, r, notFoundUrl, http.StatusTemporaryRedirect)
 		return
 	}
 

--- a/api/models/schema.go
+++ b/api/models/schema.go
@@ -22,6 +22,7 @@ type URL struct {
 	Expiry      UnixTime           `json:"expiry" validate:"required"`
 	Short       string             `json:"short" validate:"required"`
 	ID          primitive.ObjectID `json:"_id,omitempty" bson:"_id,omitempty"`
-	LastVisited UnixTime           `json:"last_visited"`
-	CreatedAt   UnixTime           `json:"created_at"`
+	UpdateAt    UnixTime           `json:"update_at" bson:"update_at"`
+	CreatedAt   UnixTime           `json:"created_at" bson:"created_at"`
+	TotalClicks int64              `json:"total_clicks" bson:"total_clicks"`
 }

--- a/api/models/url.go
+++ b/api/models/url.go
@@ -37,7 +37,7 @@ func CreateURL(user *User, short string, destination string, expiry int64) (*URL
 	url.Short = short
 	url.Destination = destination
 	url.Expiry = UnixTime(expiry)
-	url.LastVisited = UnixTime(time.Now().Unix())
+	// url.UpdateAt = UnixTime(time.Now().Unix())
 	url.CreatedAt = UnixTime(time.Now().Unix())
 	url.ID = primitive.NilObjectID
 	ctx := context.TODO()

--- a/api/tests/integration/main_test.go
+++ b/api/tests/integration/main_test.go
@@ -32,8 +32,8 @@ var (
 var UserFixture1 = models.User{Name: "Test User 1", Email: "test1@gmail.com", Picture: "https://lh3.googleusercontent.com/a-/AOh14Gh"}
 var UserFixture2 = models.User{Name: "Test User 2", Email: "test2@gmail.com", Picture: "https://lh3.googleusercontent.com/a-/AOh14Gh"}
 
-var URLFixture = &models.URL{User: primitive.NilObjectID, Destination: "https://www.google.com", Expiry: models.UnixTime(time.Now().Add(time.Hour * 5).Unix()), Short: "test", LastVisited: models.UnixTime(time.Now().Unix()), CreatedAt: models.UnixTime(time.Now().Unix())}
-var ExpiredURLFixture = &models.URL{User: primitive.NilObjectID, Destination: "https://www.google.com", Expiry: models.UnixTime(time.Now().Add(-time.Hour).Unix()), Short: "test_expired", LastVisited: models.UnixTime(time.Now().Unix()), CreatedAt: models.UnixTime(time.Now().Unix())}
+var URLFixture = &models.URL{User: primitive.NilObjectID, Destination: "https://www.google.com", Expiry: models.UnixTime(time.Now().Add(time.Hour * 5).Unix()), Short: "test", UpdateAt: models.UnixTime(time.Now().Unix()), CreatedAt: models.UnixTime(time.Now().Unix())}
+var ExpiredURLFixture = &models.URL{User: primitive.NilObjectID, Destination: "https://www.google.com", Expiry: models.UnixTime(time.Now().Add(-time.Hour).Unix()), Short: "test_expired", UpdateAt: models.UnixTime(time.Now().Unix()), CreatedAt: models.UnixTime(time.Now().Unix())}
 
 func TestMain(m *testing.M) {
 	// Set up HTTP server

--- a/api/tests/integration/url_test.go
+++ b/api/tests/integration/url_test.go
@@ -29,10 +29,10 @@ func TestURLResolve(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	notFoundurl := os.Getenv("FRONTEND_URL") + "/not-found/redirect"
+	destinationURL := URLFixture.Destination
 
-	assert.Equal(t, resp.StatusCode, http.StatusMovedPermanently, "Excpected status code to be 302")
-	assert.NotContains(t, resp.Header.Get("Location"), notFoundurl, "Expected not redirect to url-not-found page")
+	assert.Equal(t, resp.StatusCode, http.StatusMovedPermanently, "Excpected status code to be 301")
+	assert.Contains(t, resp.Header.Get("Location"), destinationURL, "Expected redirect to destination url")
 }
 
 func TestURLResolveNotFound(t *testing.T) {
@@ -43,7 +43,7 @@ func TestURLResolveNotFound(t *testing.T) {
 
 	notFoundurl := os.Getenv("FRONTEND_URL") + "/not-found/redirect"
 
-	assert.Equal(t, resp.StatusCode, http.StatusMovedPermanently, "Excpected status code to be 302")
+	assert.Equal(t, resp.StatusCode, http.StatusTemporaryRedirect, "Excpected status code to be 307")
 	assert.Contains(t, resp.Header.Get("Location"), notFoundurl, "Expected redirect to url-not-found page")
 }
 
@@ -55,7 +55,7 @@ func TestURLResolveExpired(t *testing.T) {
 
 	notFoundurl := os.Getenv("FRONTEND_URL") + "/not-found/redirect"
 
-	assert.Equal(t, resp.StatusCode, http.StatusMovedPermanently, "Excpected status code to be 302")
+	assert.Equal(t, resp.StatusCode, http.StatusTemporaryRedirect, "Excpected status code to be 302")
 	assert.Contains(t, resp.Header.Get("Location"), notFoundurl, "Expected redirect to url-not-found page")
 }
 
@@ -265,7 +265,7 @@ func TestCreateShortedUrlWithDuplicateShort(t *testing.T) {
 	assert.Equal(t, respBody["error"], "URL custom short is already in user", "Expected short to be already in use")
 }
 
-// uodate url
+// update url
 func TestUpdateURL(t *testing.T) {
 	// Data for the payload as a map
 	payloadData := map[string]interface{}{

--- a/redirect_service/main.go
+++ b/redirect_service/main.go
@@ -81,7 +81,7 @@ func ResolveURL(w http.ResponseWriter, r *http.Request) {
 	if urlExpiredOrNotFound || url == nil {
 		notFoundUrl := os.Getenv("UI_NOT_FOUND_URL")
 		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
-		http.Redirect(w, r, notFoundUrl, http.StatusMovedPermanently)
+		http.Redirect(w, r, notFoundUrl, http.StatusTemporaryRedirect)
 		return
 	}
 


### PR DESCRIPTION
# Brief
- Added `updated_at` and `total_clicks` in the URL schema
- Also remove `lastVisited` from the URL schema